### PR TITLE
feat: add flutter pos skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-#test
+# Toyland POS
+
+A simple Flutter-based point of sale app featuring inventory management and order processing.
+
+## Features
+- Inventory list with product details
+- Orders list with status
+- Form to register new orders
+
+This project uses the [`fluent_ui`](https://pub.dev/packages/fluent_ui) package for a polished UI.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,49 @@
+import 'package:fluent_ui/fluent_ui.dart';
+
+import 'pages/inventory_page.dart';
+import 'pages/order_form_page.dart';
+import 'pages/orders_page.dart';
+
+void main() {
+  runApp(const ToylandPosApp());
+}
+
+class ToylandPosApp extends StatefulWidget {
+  const ToylandPosApp({super.key});
+
+  @override
+  State<ToylandPosApp> createState() => _ToylandPosAppState();
+}
+
+class _ToylandPosAppState extends State<ToylandPosApp> {
+  int index = 0;
+
+  final pages = const [
+    InventoryPage(),
+    OrdersPage(),
+    OrderFormPage(),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return FluentApp(
+      title: 'Toyland POS',
+      theme: FluentThemeData(),
+      home: NavigationView(
+        appBar: const NavigationAppBar(
+          title: Text('Toyland POS'),
+        ),
+        pane: NavigationPane(
+          selected: index,
+          onChanged: (i) => setState(() => index = i),
+          items: const [
+            PaneItem(icon: Icon(FluentIcons.product), title: Text('Inventory')),
+            PaneItem(icon: Icon(FluentIcons.order_status), title: Text('Orders')),
+            PaneItem(icon: Icon(FluentIcons.add), title: Text('New Order')),
+          ],
+        ),
+        content: pages[index],
+      ),
+    );
+  }
+}

--- a/lib/models/order.dart
+++ b/lib/models/order.dart
@@ -1,0 +1,27 @@
+import 'product.dart';
+
+class Order {
+  final String orderNumber;
+  final Product product;
+  final DateTime createdAt;
+  final double discountedPrice;
+  final bool canceled;
+
+  const Order({
+    required this.orderNumber,
+    required this.product,
+    required this.createdAt,
+    required this.discountedPrice,
+    this.canceled = false,
+  });
+
+  double get price => product.price;
+  String get productName => product.name;
+  String get sku => product.sku;
+  String get serialNumber => product.serialNumber;
+  String get location => product.location;
+  String get vendor => product.vendor;
+  String get brand => product.brand;
+  String get uniqueCode => product.uniqueCode;
+  String get skuPlus => product.skuPlus;
+}

--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -1,0 +1,23 @@
+class Product {
+  final String name;
+  final String brand;
+  final String sku;
+  final String uniqueCode;
+  final String serialNumber;
+  final String vendor;
+  final double price;
+  final String location;
+  final String skuPlus;
+
+  const Product({
+    required this.name,
+    required this.brand,
+    required this.sku,
+    required this.uniqueCode,
+    required this.serialNumber,
+    required this.vendor,
+    required this.price,
+    required this.location,
+    required this.skuPlus,
+  });
+}

--- a/lib/pages/inventory_page.dart
+++ b/lib/pages/inventory_page.dart
@@ -1,0 +1,31 @@
+import 'package:fluent_ui/fluent_ui.dart';
+
+import '../services/repository.dart';
+
+class InventoryPage extends StatelessWidget {
+  const InventoryPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final repo = Repository();
+    return ScaffoldPage(
+      header: const PageHeader(title: Text('Inventory')),
+      content: ValueListenableBuilder(
+        valueListenable: repo.products,
+        builder: (context, products, _) {
+          return ListView.builder(
+            itemCount: products.length,
+            itemBuilder: (context, index) {
+              final product = products[index];
+              return ListTile(
+                title: Text(product.name),
+                subtitle: Text('${product.brand} • ${product.sku}'),
+                trailing: Text('\$${product.price.toStringAsFixed(2)}'),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/pages/order_form_page.dart
+++ b/lib/pages/order_form_page.dart
@@ -1,0 +1,76 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'package:flutter/services.dart';
+
+import '../models/order.dart';
+import '../models/product.dart';
+import '../services/repository.dart';
+
+class OrderFormPage extends StatefulWidget {
+  const OrderFormPage({super.key});
+
+  @override
+  State<OrderFormPage> createState() => _OrderFormPageState();
+}
+
+class _OrderFormPageState extends State<OrderFormPage> {
+  final orderNumberController = TextEditingController();
+  final discountController = TextEditingController();
+  Product? selectedProduct;
+
+  @override
+  Widget build(BuildContext context) {
+    final repo = Repository();
+    return ScaffoldPage(
+      header: const PageHeader(title: Text('New Order')),
+      content: Form(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextBox(
+              header: 'Order Number',
+              controller: orderNumberController,
+            ),
+            const SizedBox(height: 10),
+            ComboBox<Product>(
+              placeholder: const Text('Select Product'),
+              value: selectedProduct,
+              items: repo.products.value
+                  .map((p) => ComboBoxItem(value: p, child: Text(p.name)))
+                  .toList(),
+              onChanged: (p) => setState(() => selectedProduct = p),
+            ),
+            const SizedBox(height: 10),
+            TextBox(
+              header: 'Discounted Price',
+              controller: discountController,
+              inputFormatters: [
+                FilteringTextInputFormatter.allow(RegExp(r'\d+\.?\d*')),
+              ],
+            ),
+            const SizedBox(height: 10),
+            FilledButton(
+              child: const Text('Submit'),
+              onPressed: () {
+                if (selectedProduct == null || orderNumberController.text.isEmpty) {
+                  return;
+                }
+                final order = Order(
+                  orderNumber: orderNumberController.text,
+                  product: selectedProduct!,
+                  createdAt: DateTime.now(),
+                  discountedPrice:
+                      double.tryParse(discountController.text) ?? selectedProduct!.price,
+                );
+                repo.addOrder(order);
+                orderNumberController.clear();
+                discountController.clear();
+                setState(() => selectedProduct = null);
+                showSnackbar(context, const Snackbar(content: Text('Order added')));
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/orders_page.dart
+++ b/lib/pages/orders_page.dart
@@ -1,0 +1,33 @@
+import 'package:fluent_ui/fluent_ui.dart';
+
+import '../services/repository.dart';
+
+class OrdersPage extends StatelessWidget {
+  const OrdersPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final repo = Repository();
+    return ScaffoldPage(
+      header: const PageHeader(title: Text('Orders')),
+      content: ValueListenableBuilder(
+        valueListenable: repo.orders,
+        builder: (context, orders, _) {
+          return ListView.builder(
+            itemCount: orders.length,
+            itemBuilder: (context, index) {
+              final order = orders[index];
+              return ListTile(
+                title: Text(order.productName),
+                subtitle: Text('Order: ${order.orderNumber} • ${order.sku}'),
+                trailing: Text(order.canceled
+                    ? 'Canceled'
+                    : '\$${order.discountedPrice.toStringAsFixed(2)}'),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/services/repository.dart
+++ b/lib/services/repository.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/foundation.dart';
+
+import '../models/order.dart';
+import '../models/product.dart';
+
+class Repository {
+  Repository._internal();
+  static final Repository _instance = Repository._internal();
+  factory Repository() => _instance;
+
+  final ValueNotifier<List<Product>> products = ValueNotifier<List<Product>>([
+    const Product(
+      name: 'Sample Toy',
+      brand: 'Acme',
+      sku: 'SKU001',
+      uniqueCode: 'UC001',
+      serialNumber: 'SN001',
+      vendor: 'ToyVendor',
+      price: 10.0,
+      location: 'Aisle 1',
+      skuPlus: 'SKU001-PLUS',
+    ),
+  ]);
+
+  final ValueNotifier<List<Order>> orders = ValueNotifier<List<Order>>([]);
+
+  void addProduct(Product product) {
+    products.value = [...products.value, product];
+  }
+
+  void addOrder(Order order) {
+    orders.value = [...orders.value, order];
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,19 @@
+name: toyland_pos
+description: A Flutter POS app for inventory and orders.
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  fluent_ui: ^4.6.3
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- scaffold Toyland POS Flutter app with Fluent UI
- implement models for products and orders
- add inventory list, orders list and order creation form

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ad5adbdddc832a9424327c908c18c2