### PR TITLE
Add basic Flutter POS app with inventory and orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ A simple Flutter-based point of sale app featuring inventory management and orde
 - Form to register new orders
 
 This project uses the [`fluent_ui`](https://pub.dev/packages/fluent_ui) package for a polished UI.
+
+## Running
+Ensure you have the [Flutter SDK](https://flutter.dev/desktop) installed with desktop support enabled.
+
+```bash
+flutter pub get
+flutter run -d windows   # or `-d linux`/`-d macos`
+```

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,91 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import 'models/product.dart';
+import 'models/order.dart';
+import 'pages/inventory_page.dart';
+import 'pages/orders_page.dart';
+import 'pages/order_form_page.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatefulWidget {
+  const MyApp({super.key});
+
+  @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  final List<Product> products = [
+    const Product(
+      name: 'Toy Car',
+      brand: 'FunBrand',
+      sku: 'TC001',
+      uniqueCode: 'UNIQ001',
+      serialNumber: 'SN123',
+      vendor: 'ToyVendor',
+      price: 10.0,
+      location: 'A1',
+      skuPlus: 'TC001-PLUS',
+    ),
+    const Product(
+      name: 'Doll',
+      brand: 'PlayCo',
+      sku: 'DL002',
+      uniqueCode: 'UNIQ002',
+      serialNumber: 'SN456',
+      vendor: 'ToyVendor',
+      price: 15.5,
+      location: 'B2',
+      skuPlus: 'DL002-PLUS',
+    ),
+  ];
+
+  final List<Order> orders = [];
+  int nextOrderNumber = 1;
+  int index = 0;
+
+  void _addOrder(Order order) {
+    setState(() {
+      orders.add(order);
+      nextOrderNumber++;
+      index = 1; // switch to orders page after creation
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FluentApp(
+      title: 'Toyland POS',
+      home: NavigationView(
+        pane: NavigationPane(
+          selected: index,
+          onChanged: (i) => setState(() => index = i),
+          displayMode: PaneDisplayMode.top,
+          items: [
+            PaneItem(
+              icon: const Icon(FluentIcons.cube),
+              title: const Text('Inventory'),
+              body: InventoryPage(products: products),
+            ),
+            PaneItem(
+              icon: const Icon(FluentIcons.shopping_cart),
+              title: const Text('Orders'),
+              body: OrdersPage(orders: orders),
+            ),
+            PaneItem(
+              icon: const Icon(FluentIcons.add),
+              title: const Text('New Order'),
+              body: OrderFormPage(
+                products: products,
+                onCreate: _addOrder,
+                nextOrderNumber: nextOrderNumber,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/models/order.dart
+++ b/lib/models/order.dart
@@ -1,0 +1,31 @@
+import 'product.dart';
+
+class Order {
+  final int orderNumber;
+  final Product product;
+  final String serialNumber;
+  final DateTime createdAt;
+  final double price;
+  final double discountedPrice;
+  final String location;
+  final String vendor;
+  final String brand;
+  final String uniqueCode;
+  final bool canceled;
+  final String skuPlus;
+
+  Order({
+    required this.orderNumber,
+    required this.product,
+    required this.serialNumber,
+    required this.createdAt,
+    required this.price,
+    required this.discountedPrice,
+    required this.location,
+    required this.vendor,
+    required this.brand,
+    required this.uniqueCode,
+    this.canceled = false,
+    required this.skuPlus,
+  });
+}

--- a/lib/models/product.dart
+++ b/lib/models/product.dart
@@ -1,0 +1,23 @@
+class Product {
+  final String name;
+  final String brand;
+  final String sku;
+  final String uniqueCode;
+  final String serialNumber;
+  final String vendor;
+  final double price;
+  final String location;
+  final String skuPlus;
+
+  const Product({
+    required this.name,
+    required this.brand,
+    required this.sku,
+    required this.uniqueCode,
+    required this.serialNumber,
+    required this.vendor,
+    required this.price,
+    required this.location,
+    required this.skuPlus,
+  });
+}

--- a/lib/pages/inventory_page.dart
+++ b/lib/pages/inventory_page.dart
@@ -1,0 +1,28 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import '../models/product.dart';
+
+class InventoryPage extends StatelessWidget {
+  final List<Product> products;
+  const InventoryPage({super.key, required this.products});
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaffoldPage(
+      header: const PageHeader(title: Text('Inventory')),
+      content: ListView.builder(
+        itemCount: products.length,
+        itemBuilder: (context, index) {
+          final product = products[index];
+          return Card(
+            child: ListTile(
+              title: Text(product.name),
+              subtitle: Text(
+                'SKU: ${product.sku}\nBrand: ${product.brand}\nVendor: ${product.vendor}\nPrice: ${product.price}\nLocation: ${product.location}\nSerial: ${product.serialNumber}\nUnique: ${product.uniqueCode}\nSKU+: ${product.skuPlus}',
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/pages/order_form_page.dart
+++ b/lib/pages/order_form_page.dart
@@ -1,0 +1,83 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import '../models/order.dart';
+import '../models/product.dart';
+
+class OrderFormPage extends StatefulWidget {
+  final List<Product> products;
+  final void Function(Order order) onCreate;
+  final int nextOrderNumber;
+
+  const OrderFormPage({
+    super.key,
+    required this.products,
+    required this.onCreate,
+    required this.nextOrderNumber,
+  });
+
+  @override
+  State<OrderFormPage> createState() => _OrderFormPageState();
+}
+
+class _OrderFormPageState extends State<OrderFormPage> {
+  final _formKey = GlobalKey<FormState>();
+  Product? selectedProduct;
+  double discount = 0.0;
+
+  void _submit() {
+    if (_formKey.currentState!.validate() && selectedProduct != null) {
+      _formKey.currentState!.save();
+      final p = selectedProduct!;
+      final order = Order(
+        orderNumber: widget.nextOrderNumber,
+        product: p,
+        serialNumber: p.serialNumber,
+        createdAt: DateTime.now(),
+        price: p.price,
+        discountedPrice: p.price - discount,
+        location: p.location,
+        vendor: p.vendor,
+        brand: p.brand,
+        uniqueCode: p.uniqueCode,
+        skuPlus: p.skuPlus,
+      );
+      widget.onCreate(order);
+      Navigator.pop(context);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaffoldPage(
+      header: const PageHeader(title: Text('Register Order')),
+      content: Form(
+        key: _formKey,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 12),
+            ComboBox<Product>(
+              placeholder: const Text('Select product'),
+              items: widget.products
+                  .map((p) => ComboBoxItem<Product>(value: p, child: Text(p.name)))
+                  .toList(),
+              value: selectedProduct,
+              onChanged: (p) => setState(() => selectedProduct = p),
+            ),
+            const SizedBox(height: 12),
+            TextFormBox(
+              header: 'Discount',
+              placeholder: '0',
+              onSaved: (v) => discount = double.tryParse(v ?? '0') ?? 0,
+              validator: (v) => double.tryParse(v ?? '') != null ? null : 'Enter a number',
+            ),
+            const SizedBox(height: 20),
+            FilledButton(
+              onPressed: _submit,
+              child: const Text('Submit'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/orders_page.dart
+++ b/lib/pages/orders_page.dart
@@ -1,0 +1,28 @@
+import 'package:fluent_ui/fluent_ui.dart';
+import '../models/order.dart';
+
+class OrdersPage extends StatelessWidget {
+  final List<Order> orders;
+  const OrdersPage({super.key, required this.orders});
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaffoldPage(
+      header: const PageHeader(title: Text('Orders')),
+      content: ListView.builder(
+        itemCount: orders.length,
+        itemBuilder: (context, index) {
+          final order = orders[index];
+          return Card(
+            child: ListTile(
+              title: Text('Order #${order.orderNumber} - ${order.product.name}'),
+              subtitle: Text(
+                'SKU: ${order.product.sku}\nSerial: ${order.serialNumber}\nTime: ${order.createdAt}\nPrice: ${order.price}\nDiscounted: ${order.discountedPrice}\nLocation: ${order.location}\nVendor: ${order.vendor}\nBrand: ${order.brand}\nUnique: ${order.uniqueCode}\nCanceled: ${order.canceled}\nSKU+: ${order.skuPlus}',
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Scaffold POS app with fluent UI and navigation
- Implement inventory and orders models and pages
- Provide order registration form and desktop run instructions

## Testing
- `apt-get update` *(fails: 403 Forbidden)*
- `flutter analyze` *(fails: command not found)*
- `dart format .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ad8710a600832a9b8a068d37f073c5